### PR TITLE
Fixed jlemmagen dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>eu.hlavki.text</groupId>
             <artifactId>jlemmagen</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>1.0</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
Hi Michal,

it seems that jlemmagen version `1.0-SNAPSHOT` is not available. This PR changes the version to `1.0`.